### PR TITLE
feat(run-scan): add entrypoints parameter

### DIFF
--- a/run-scan/action.yml
+++ b/run-scan/action.yml
@@ -44,6 +44,9 @@ inputs:
   tests:
     description: 'A list of tests which you want to run during a scan.'
     required: false
+  entrypoints:
+    description: 'A list of entrypoints which you want to scan.'
+    required: false
 
 outputs:
   url:

--- a/run-scan/src/config.ts
+++ b/run-scan/src/config.ts
@@ -23,6 +23,7 @@ export interface Config {
   projectId?: string;
   hostsFilter?: string[];
   tests?: TestType[];
+  entryPointIds?: string[];
 }
 
 const invalidUrlProtocols: ReadonlySet<string> = new Set<string>([

--- a/run-scan/src/index.ts
+++ b/run-scan/src/index.ts
@@ -35,6 +35,7 @@ const module_in = core.getInput('module');
 const hostsFilter = getArray('hosts_filter');
 const type = core.getInput('type');
 const hostname = core.getInput('hostname');
+const entrypoints = getArray('entrypoints');
 
 const baseUrl = hostname ? `https://${hostname}` : 'https://app.brightsec.com';
 
@@ -111,10 +112,12 @@ if (restartScanID) {
     ? [Discovery.ARCHIVE]
     : discoveryTypesIn;
   const uniqueTests = tests ? [...new Set(tests)] : undefined;
+
   const config: Config = {
     name,
     discoveryTypes,
     module,
+    entryPointIds: entrypoints,
     ...(crawlerUrls ? { crawlerUrls } : {}),
     ...(fileId ? { fileId } : {}),
     ...(projectId ? { projectId } : {}),


### PR DESCRIPTION
Add support to `entrypoints` parameter for scans. If it's empty, then default 2000 entrypoints are used only if `projectId` isn't empty.